### PR TITLE
maint/dev ~ fix missing yargs types

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^14.14.0",
+    "@types/yargs": "^15.0.12",
     "typescript": "^4.0.3"
   },
   "dependencies": {


### PR DESCRIPTION
fixes build error: `src/index.ts:3:19 - error TS2307: Cannot find module 'yargs-parser' or its corresponding type declarations.`