### PR TITLE
Improve has files check (fixes #15)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -83,7 +83,7 @@ export async function cli(args: string[]) {
     title: 'No Unnecessary Files',
     url: 'https://docs.skypack.dev/package-authors/package-checks#files',
     pass: () => {
-      return !!pkg.files;
+      return !!pkg.files || !!files.includes('.npmignore');
     },
   });
   // Check: Has "keywords"


### PR DESCRIPTION
The _has files check_ currently only checks the existence of a `files` property in the `package.json` file. But according to the [npm docs](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#files) you can also use a `.npmignore` file to do so:

> You can also provide a .npmignore file in the root of your package or in subdirectories, which will keep files from being included.

This MR adds a condition to check if a `.npmignore` file is present so it can pass the test without a `files` property.