### PR TITLE
Log working directory

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,10 @@ export async function cli(args: string[]) {
   const cliFlags = yargs(args, {});
   const cwd = cliFlags.cwd ? path.resolve(cliFlags.cwd) : process.cwd();
   const files = fs.readdirSync(cwd);
-
+  
+  // print the working directory
+  console.error(colors.dim(`checking: ${cwd}`));
+  
   // Check: Has a package.json
   runCheck({
     title: 'package.json',


### PR DESCRIPTION
In cases where this might get run in more then one place at once like a monorepo via `yarn run` `npm run --ws` or `lerna exec` it would be helpful to print the directory to identify where an error took place. https://github.com/skypackjs/package-check/issues/19