### PR TITLE
add @skypack scope to npx instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ yarn run package-check
 ```
 # npm (run this in your package directory)
 npm install @skypack/package-check --dev
-npx package-check
+npx @skypack/package-check
 ```
 
 


### PR DESCRIPTION
Currently the README `npx` instructions are:

`npx package-check` which will return a 404

I've updated the README to this:

`npx @skypack/package-check`